### PR TITLE
Render campaign panel headers in candidate.html

### DIFF
--- a/assets/js/candidate.js
+++ b/assets/js/candidate.js
@@ -1,0 +1,33 @@
+var apiRoot = 'http://api.leveragecampaignfinance.org';
+
+function setApiRoot (root) {
+  return function getEndpoint (path) {
+    return root + path;
+  }
+}
+
+function getParams () {
+  if (!window.location.search) return;
+  var params = {};
+  var qstring = window.location.search.slice(1);
+  qstring.split('&').forEach(function (param) {
+    [key, val] = param.split('=')
+    params[key] = val;
+  });
+  return params;
+}
+
+$(document).ready(function(){
+  var getEndpoint = setApiRoot(apiRoot);
+  var params = getParams();
+  if (!params.id) return;
+  var endpoint = getEndpoint('/candidates/' + params.id);
+  $.get(endpoint, function(candidate){
+    $('#candidate-name').text(candidate.candidate_name);
+    var template = $('#campaign-panel-template').html();
+    candidate.campaigns.forEach(function (campaign) {
+      var element = $.parseHTML(Mustache.render(template, campaign));
+      $('#campaigns-panel').append(element);
+    });
+  });
+});

--- a/candidate.html
+++ b/candidate.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.4/nv.d3.min.css">
+  </head>
+  <body>
+
+    <nav class='navbar navbar-default' id='navbar'>
+      <section class='container-fluid'>
+        <section class='navbar-header' id='nav-header-block'>
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#nav-links-block" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class='navbar-brand' href='/'>Leverage</a>
+        </section>
+        <section class='collapse navbar-collapse' id='nav-links-block'>
+          <ul class='nav navbar-nav' id='nav-links'>
+            <li><a href='/'>Discover data</a></li>
+            <li><a href='/getting-started.html'>Getting started</a></li>
+            <li><a href='/about.html'>About Leverage</a></li>
+          </ul>
+        </section>
+      </section>
+    </nav>
+
+    <section class='container' id='body'>
+
+      <header class='page-header'>
+        <h1 id='candidate-name'></h1>
+      </header>
+
+      <main id='campaigns-panel'>
+      </main>
+
+    </section>
+
+    <script id='campaign-panel-template' type='text/template'>
+      <section class='campaign panel panel-default'>
+        <header class='panel-header'>
+          <section class='row text-center'>
+            <section class='col-md-4'>
+              <p>Year</p>
+              <p class='h4'>{{ election_year }}</p>
+            </section>
+            <section class='col-md-4'>
+              <p>Office</p>
+              <p class='h4'>{{ candidate_position }}</p>
+            </section>
+            <section class='col-md-4'>
+              <p>Party</p>
+              <p class='h4'>{{ candidate_party }}</p>
+            </section>
+          </section>
+        </header>
+        <section class='panel-body'>
+          <!-- Histogram goes here -->
+        </section>
+      </section>
+    </script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.2.1/mustache.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.4/nv.d3.min.js"></script>
+    <script src="/assets/js/candidate.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a basic candidate.html page and candidate.js script which fetches and renders a candidate object. The page expects to receive the querystring parameter `id` set to the id of the candidate to be rendered. For example, the url:

`http://leveragecampaignfinance.org/candidate.html?id=1`

Would render the candidate page with the data associated with the candidate of id 1.

This PR does not implement the contributions histogram.
Resolves #8.
