### PR TITLE
Create HTML templates for About, How to Use, and Discovery pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Bootstrap core CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  </head>
+  <body>
+
+    <nav class='navbar navbar-default' id='navbar'>
+      <section class='container-fluid'>
+        <section class='navbar-header' id='nav-header-block'>
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#nav-links-block" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class='navbar-brand' href='discover.html'>Leverage</a>
+        </section>
+        <section class='collapse navbar-collapse' id='nav-links-block'>
+          <ul class='nav navbar-nav' id='nav-links'>
+            <li><a href='getting-started.html'>Getting started</a></li>
+            <li><a href='discover.html'>Discover data</a></li>
+            <li class='active'><a>About Leverage</a></li>
+          </ul>
+        </section>
+      </section>
+    </nav>
+
+    <!-- PAGE CONTENT -->
+    <div class="container">
+      <h2>About Leverage</h2>
+      <p>Leverage takes Philadelphia campaign finance data, analyzes it, and makes it easy for anyone to consume. Our goal is to empower citizens of Philadelphia to use campaign finance data when making informed decisions about who they donate to, who they support, and who they vote for.</p>
+      <p>The foundation of Leverage is the campaign finance data published by the City of Philadelphia. We apply machine learning techniques to the data to pull out trends and patterns. Finally, we add a layer of simple visualization on top of the analyzed data, allowing any citizen to access the information and understand how candidates are funded.</p>
+
+      <h2>Our Guiding Principles</h2>
+      <ul>
+        <li>Empower citizens to make informed decisions.</li>
+        <li>Don't single out individual donors; don't facilitate punitive actions.</li>
+        <li>Design visualizations so they can be consumed by anyone.</li>
+      </ul>
+
+      <h2>About the Leverage Team</h2>
+      <p>The team is group of volunteers that strives to create positive social and political change through technology. We come from a variety of backgrounds, industries, and professions.</p>
+      <p>The team formed during the Code for Philly Democracy Hackathon in March 2016.</p>
+    </div>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/discover.html
+++ b/discover.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Bootstrap core CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  </head>
+  <body>
+
+    <nav class='navbar navbar-default' id='navbar'>
+      <section class='container-fluid'>
+        <section class='navbar-header' id='nav-header-block'>
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#nav-links-block" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class='navbar-brand'>Leverage</a>
+        </section>
+        <section class='collapse navbar-collapse' id='nav-links-block'>
+          <ul class='nav navbar-nav' id='nav-links'>
+            <li><a href='getting-started.html'>Getting started</a></li>
+            <li class="active"><a>Discover data</a></li>
+            <li><a href='about.html'>About Leverage</a></li>
+          </ul>
+        </section>
+      </section>
+    </nav>
+
+    <!-- PAGE CONTENT -->
+    <div class="container">
+      <h1>Candidates</h1>
+      <table class="table table-hover">
+        <tr>
+          <th>Name</th>
+          <th>Position</th>
+        </tr>
+        <tr>
+          <td><a href="candidate.html?ID=#">Lynne Abraham</a></td>
+          <td>Mayor</td>
+        </tr>
+        <tr>
+          <td><a href="candidate.html?ID=#">Nelson Diaz</a></td>
+          <td>Mayor</td>
+        </tr>
+        <tr>
+          <td><a href="candidate.html?ID=#">Jim Kenney</a></td>
+          <td>Mayor</td>
+        </tr>
+        <tr>
+          <td><a href="candidate.html?ID=#">Melissa Murray Bailey</a></td>
+          <td>Mayor</td>
+        </tr>
+        <tr>
+          <td><a href="candidate.html?ID=#">Doug Oliver</a></td>
+          <td>Mayor</td>
+        </tr>
+        <tr>
+          <td><a href="candidate.html?ID=#">Milton Street</a></td>
+          <td>Mayor</td>
+        </tr>
+        <tr>
+          <td><a href="candidate.html?ID=#">Ken Trujillo</a></td>
+          <td>Mayor</td>
+        </tr>
+        <tr>
+          <td><a href="candidate.html?ID=#">Anthony Williams</a></td>
+          <td>Mayor</td>
+        </tr>
+      </table>
+    </div>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/getting-started.html
+++ b/getting-started.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Bootstrap core CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  </head>
+  <body>
+
+    <nav class='navbar navbar-default' id='navbar'>
+      <section class='container-fluid'>
+        <section class='navbar-header' id='nav-header-block'>
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#nav-links-block" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class='navbar-brand' href='discover.html'>Leverage</a>
+        </section>
+        <section class='collapse navbar-collapse' id='nav-links-block'>
+          <ul class='nav navbar-nav' id='nav-links'>
+            <li class='active'><a>Getting started</a></li>
+            <li><a href='discover.html'>Discover data</a></li>
+            <li><a href='about.html'>About Leverage</a></li>
+          </ul>
+        </section>
+      </section>
+    </nav>
+
+    <!-- PAGE CONTENT -->
+    <div class="container">
+      <h2>Candidate Listing</h2>
+      <p>The discovery page lists candidates whose financial data is available in Leverage. Click a candidate's name to view their campaign financial details.</p>
+
+      <h2>Candidate Detail Page</h2>
+      <p>The candidate detail page provides fundamental information about a candidate's campaign as well as relevant financial data.</p>
+    </div>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds in basic about.html, getting-started.html, and discover.html pages. They contain no scripting: they're just static HTML pages.

discover.html needs to be updated to
1. Generate the candidates table according to values pulled through the API
2. Dynamically generate links to the candidate pages in the form of `candidate.html?id=#`. See #12 for details.

Resolves #4, #5, #6. Resolves ~25% of #3.
