### PR TITLE
Complete scaffolding with index.html/index.js example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,14 @@ CSS_SRCS      :=                                           \
 	$(VENDOR_PREFIX)/bootstrap/dist/css/bootstrap.min.css    \
 	$(VENDOR_PREFIX)/animate.css/animate.min.css
 JS_SRCS       :=                                           \
-	$(SRC_PREFIX)/js/core.js
+	$(SRC_PREFIX)/js/core.js                                 \
+	$(SRC_PREFIX)/js/entrypoint.js                           \
+	$(SRC_PREFIX)/js/index.js
 
 BUILD_FILES   :=                                           \
 	$(BUILD_PREFIX)/css/style.css                            \
-	$(BUILD_PREFIX)/js/app.js
+	$(BUILD_PREFIX)/js/app.js                                \
+	$(BUILD_PREFIX)/index.html
 
 site: $(BUILD_FILES)
 
@@ -29,7 +32,10 @@ $(BUILD_PREFIX)/%.html: $(SRC_PREFIX)/html/%.html
 	@parent=$$(dirname "$@"); test -e "$$parent" || mkdir -p "$$parent"
 	cp $< $@
 
+test:
+	npm test
+
 clean:
 	rm -rf $(BUILD_PREFIX)
 
-.PHONY: site
+.PHONY: site test clean

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <link rel='stylesheet' href='/css/style.css'>
+  </head>
+  <body>
+    <script src='/js/app.js'></script>
+  </body>
+</html>

--- a/src/js/config.json
+++ b/src/js/config.json
@@ -1,5 +1,6 @@
 {
   "development": {
-    "api_prefix": "http://localhost:5000/api"
+    "api_prefix": "http://localhost:5000/api",
+    "rootPage": "index.html"
   }
 }

--- a/src/js/entrypoint.js
+++ b/src/js/entrypoint.js
@@ -1,0 +1,10 @@
+var entrypointMap = {
+  'index.html': require('./index')
+};
+
+var path = require('path');
+var core = require('./core');
+var page = path.basename(window.location.pathname) || core.cfg.rootPage;
+var entrypoint = entrypointMap[page] || (() => undefined);
+
+entrypoint(core);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,0 +1,1 @@
+module.exports = (core) => undefined;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,1 +1,1 @@
-module.exports = (core) => undefined;
+module.exports = (core) => console.log(JSON.stringify(core.cfg));


### PR DESCRIPTION
This scaffolding lends itself to a workflow where each page is mapped to a different JS module. The module for that page is then expected to export a single function which accepts a single argument, that argument being the core module. The specific steps for adding a page with executing JS code:

1. Create `${pageName}.html` under the `src/html` directory
2. Create a matching module for `${pageName}.html` under `src/js`. This module should export a function which accepts the core object as an argument (see `index.js` for an example).
3. Map the page name to the module within `src/js/entrypoint.js` using the `entrypointMap` object (see `entrypointMap` in `entrypoint.js` for an example).
4. Add the JS *source module* to the build under `JS_SRCS` in the Makefile
5. Add the HTML file *destination path* to the build under `BUILD_FILES` in the Makefile